### PR TITLE
Adding fields for Navigator for the new HST groups

### DIFF
--- a/src/models/InteractiveSubject.coffee
+++ b/src/models/InteractiveSubject.coffee
@@ -26,7 +26,7 @@ class InteractiveSubject extends Spine.Model
   @fromJSON: (json) =>
     @lastFetch = new Array
     for result in json
-      if result.recent.subjects[0]?.metadata?.survey is 'sloan'
+      if result.recent.subjects[0]?.metadata?.survey is 'sloan' or result.recent.subjects[0]?.metadata?.survey is 'sloan_singleband'
         item = @create
           counters: result.recent.subjects[0].metadata.counters
           classification: result.recent.user.classification
@@ -36,6 +36,30 @@ class InteractiveSubject extends Spine.Model
           absolute_brightness: result.recent.subjects[0].metadata.mag?.abs_r
           apparent_brightness: result.recent.subjects[0].metadata.mag?.r
           color: result.recent.subjects[0].metadata.mag?.u - result.recent.subjects[0].metadata.mag?.r
+          absolute_radius: result.recent.subjects[0].metadata.absolute_size
+
+      if result.recent.subjects[0]?.metadata?.survey is 'candels_2epoch'
+        item = @create
+          counters: result.recent.subjects[0].metadata.counters
+          classification: result.recent.user.classification
+          image: result.recent.subjects[0].location.standard
+          zooniverse_id: result.recent.subjects[0].zooniverse_id
+          redshift: result.recent.subjects[0].metadata.redshift
+          absolute_brightness: result.recent.subjects[0].metadata.mag?.abs_H
+          apparent_brightness: result.recent.subjects[0].metadata.mag?.H
+          color: result.recent.subjects[0].metadata.mag?.H - result.recent.subjects[0].metadata.mag?.J
+          absolute_radius: result.recent.subjects[0].metadata.absolute_size
+
+      if result.recent.subjects[0]?.metadata?.survey is 'goods_full'
+        item = @create
+          counters: result.recent.subjects[0].metadata.counters
+          classification: result.recent.user.classification
+          image: result.recent.subjects[0].location.standard
+          zooniverse_id: result.recent.subjects[0].zooniverse_id
+          redshift: result.recent.subjects[0].metadata.redshift
+          absolute_brightness: result.recent.subjects[0].metadata.mag?.abs_Z
+          apparent_brightness: result.recent.subjects[0].metadata.mag?.Z
+          color: result.recent.subjects[0].metadata.mag?.I - result.recent.subjects[0].metadata.mag?.Z
           absolute_radius: result.recent.subjects[0].metadata.absolute_size
 
         @lastFetch.push item


### PR DESCRIPTION
Renaming the metadata fields that Navigator needs to plot graphs for the `candels_2epoch` and `goods_full` groups. 
