### PR TITLE
Field names magnitude, size for new DECaLS and Illustris samples

### DIFF
--- a/src/models/InteractiveSubject.coffee
+++ b/src/models/InteractiveSubject.coffee
@@ -26,7 +26,7 @@ class InteractiveSubject extends Spine.Model
   @fromJSON: (json) =>
     @lastFetch = new Array
     for result in json
-      if result.recent.subjects[0]?.metadata?.survey is 'sloan' or result.recent.subjects[0]?.metadata?.survey is 'sloan_singleband'
+      if result.recent.subjects[0]?.metadata?.survey in ('sloan','sloan_singleband','decals')
         item = @create
           counters: result.recent.subjects[0].metadata.counters
           classification: result.recent.user.classification
@@ -37,6 +37,18 @@ class InteractiveSubject extends Spine.Model
           apparent_brightness: result.recent.subjects[0].metadata.mag?.r
           color: result.recent.subjects[0].metadata.mag?.u - result.recent.subjects[0].metadata.mag?.r
           absolute_radius: result.recent.subjects[0].metadata.absolute_size
+
+      else if result.recent.subjects[0]?.metadata?.survey is 'illustris'
+        item = @create
+          counters: result.recent.subjects[0].metadata.counters
+          classification: result.recent.user.classification
+          image: result.recent.subjects[0].location.standard
+          zooniverse_id: result.recent.subjects[0].zooniverse_id
+          redshift: result.recent.subjects[0].metadata.redshift
+          absolute_brightness: result.recent.subjects[0].metadata.mag?.absmag_r
+          apparent_brightness: result.recent.subjects[0].metadata.mag?.absmag_r - 36.756
+          color: result.recent.subjects[0].metadata.mag?.absmag_u - result.recent.subjects[0].metadata.mag?.absmag_r
+          absolute_radius: result.recent.subjects[0].metadata.radius_half
 
       else if result.recent.subjects[0]?.metadata?.survey is 'candels_2epoch'
         item = @create


### PR DESCRIPTION
Adding field names for the two new samples coming into Galaxy Zoo soon. The main goal is to make sure Navigator will still work with the new subjects. @edpaget - can you tell me if there's anything else we need to do to make sure it works?

Here's an example of the metadata for a DECaLS subject:

``` json
"id":"55a7d7a27a726119cd000000",
"coords":{
"0":149.31830701390444,
"1":1.1932075529776236
},
"location":{
"standard":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/decals/standard/J095716.39+011135.4_standard.jpg",
"inverted":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/decals/inverted/J095716.39+011135.4_inverted.jpg",
"thumbnail":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/decals/thumbnail/J095716.39+011135.4_thumbnail.jpg"
},
"metadata":{
"absolute_size":6.302852646875891,
"counters":{
"feature":0,
"smooth":0,
"star":0
},
"mag":{
"faruv":22.871854789555073,
"nearuv":22.066381014883518,
"u":19.241107404232025,
"g":17.313830852508545,
"r":16.64437234401703,
"i":16.19781732559204,
"z":16.0023832321167,
"abs_r":"-19.8862247467041"
},
"petrorad_50_r":2.2243847846984863,
"petroflux_r":152.1094970703125,
"petrorad_r":5.1281514167785645,
"redshift":0.06319393962621689,
"retire_at":40,
"provided_image_id":"J095716.39+011135.4",
"survey":"decals"
},
"coords":[
149.31830701390444,
1.1932075529776236
]
}
```

and an Illustris subject:

``` json
{
"id":"55a818227a72617753000000",
"metadata":{
"simulation":"Illustris-1",
"survey":"illustris",
"snapshot":135,
"subdir":0,
"subhalo_id":25,
"camera":0,
"background":0,
"bands":"grz",
"mass_log_msun":11.540604732747191,
"radius_half":9.2236,
"sfr":0,
"mag":{
"absmag_b":"-20.5423",
"absmag_g":"-21.0227",
"absmag_i":"-22.2217",
"absmag_k":"-24.6015",
"absmag_r":"-21.8334",
"absmag_u":"-20.0077",
"absmag_v":"-21.4726",
"absmag_z":"-22.5105"
},
"priority":"fixed_view",
"provided_image_id":"synthetic_image_25_camera_0_bg_0"
},
"location":{
"standard":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/illustris/standard/synthetic_image_25_camera_0_bg_0.png",
"inverted":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/illustris/inverted/synthetic_image_25_camera_0_bg_0.png",
"thumbnail":"http://www.galaxyzoo.org.s3.amazonaws.com/subjects/illustris/thumbnail/synthetic_image_25_camera_0_bg_0.png"
}
}
```
